### PR TITLE
Added the possibility to disregard redirects while scanning

### DIFF
--- a/heimdall.py
+++ b/heimdall.py
@@ -87,6 +87,10 @@ parser.add_argument("--user-agent",
                     default=None,
                     help="Customize the User-Agent. Default: Random User-Agent")
 
+parser.add_argument("--no-redirects",
+                    action="store_false",
+                    help="Disables that redirects should be followed.")
+
 parser.add_argument("--update",
                     action="store_true",
                     default=False,

--- a/src/core/banner.py
+++ b/src/core/banner.py
@@ -53,6 +53,7 @@ Optional Arguments:
    -p, --proxy            Use a proxy to connect to the target URL
    --random-proxy         Use a random anonymous proxy
    --user-agent           Customize the User-Agent. Default: Random User-Agent
+   --no-redirects         Option to disregard redirects to avoid false positives.
    --update               Upgrade Heimdall to its latest available version.
    
    --no-update            Disables the intention of updates

--- a/src/finder.py
+++ b/src/finder.py
@@ -47,11 +47,13 @@ class Finder:
         self._wordlist = args.wordlist
         self._proxy = args.proxy
         self._user_agent = args.user_agent
+        self._no_redirects = args.no_redirects
         self.path_out = ""
 
     def dashboard(self) -> None:
         """Heimdall, Dashboard!"""
 
+        Color.println("{+} Follow redirects: %s" % self._no_redirects)
         Color.println("{+} User-Agent: %s" % self._user_agent['User-Agent'])
 
         # Format the target URL as simple and select the output directory.
@@ -67,6 +69,7 @@ class Finder:
         output_info.writelines(f"[+] URL (Target): {self._url}\n"
                                f"[+] Proxy: {self._proxy}\n"
                                f"[+] User-Agent: {self._user_agent}\n"
+                               f"[+] Allow-Redirects: {self._no_redirects}\n"
                                f"[+] Output: {self.path_out}\n\n"
                                f"[+] Wordlist: {self._wordlist}")
         output_info.close()
@@ -82,7 +85,10 @@ class Finder:
             if target not in self.scanned:
 
                 self.scanned.append(target)
+
                 request = get(target, proxies=self._proxy, headers=self._user_agent)
+                if self._no_redirects is False:
+                    request = get(target, proxies=self._proxy, headers=self._user_agent, allow_redirects=self._no_redirects)
 
                 if request.status_code == 200:
                     # Create the file "sites-found.txt" to write the possible directories found.


### PR DESCRIPTION
In many cases (especially WordPress), SEO-"experts" and admins tend to use plugins or .htaccess or other redirecting methods to redirect 404 pages via a 301 to the homepage. This leads to Heimdall thinking it is a valid admin-interface because it get's a 200 response after the 301 redirect. My PR introduces the argument `--no-redirects`, which fixes that.